### PR TITLE
Bugfix: only assign direction for attack and move

### DIFF
--- a/lib/battle_box_web/views/robot_game_view.ex
+++ b/lib/battle_box_web/views/robot_game_view.ex
@@ -68,7 +68,7 @@ defmodule BattleBoxWeb.RobotGameView do
         direction = move_direction(current_location, target)
         "failed-move #{direction}"
 
-      %{"target" => target, "type" => type} ->
+      %{"target" => target, "type" => type} when type in ["attack", "move"] ->
         direction = move_direction(current_location, target)
         "#{type} #{direction}"
 


### PR DESCRIPTION
In replay games, guarding doesn't have a target, I took this to mean
that only attack and move actions have a target and used that to
differentiate the types.

In a live game, the guard action has a target of your own square, which
resulted in an undefined direction of {0, 0} and a crash.